### PR TITLE
fix: scroll issues

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -106,7 +106,6 @@ div {
 
 html, body {
   overflow-x: hidden;
-  height: 100%;
   /* width: 100vw; */
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Hola buenas, paso a dar una mano arreglando unos errores de scrolling que encontré mientras usaba el combinador 

El error se produce debido a que `<main>` ocupa el 100% de la pantalla pero su contenido es mucho mas alto (esta condición se da únicamente en celulares prácticamente), lo que hace que el contenido de `<main>` se vuelva scrolleable.

Al tener un `<main>` scrolleable junto con el body scrolleable (dado que el `<footer>` queda debajo) se da ambigüedad acerca de donde se esta produciendo el gesto de scrolleo, lo que es molesto y puede confundir al usuario 

Adjunto un video donde intente mostrar lo que pasa, espero que se entienda. Se puede probar en ceitba.org.ar/scheduler por el momento. En el video muestro que esto sucede con la grilla de carreras, pero también se da cuando uno esta dentro de una carrera especifica seleccionando materias/comisiones.

Muy bueno el diseño del combinador, quedo incredible, saludos 🙌