### PR TITLE
feat: Allow selecting subjects via search params

### DIFF
--- a/app/[career]/page.tsx
+++ b/app/[career]/page.tsx
@@ -6,7 +6,7 @@ import { SettingsView } from "../components/SettingsView";
 import { SchedulerPreview } from "../components/SchedulerPreview";
 import TopBar from "../components/Topbar";
 import CommissionSelectionModal from "../components/CommissionSelectionModal";
-import { Subject } from "../hooks/useSubjects";
+import { Subject, useSubjects } from "../hooks/useSubjects";
 import { useState, useEffect, useRef } from "react";
 import { normalizePlanId, denormalizePlanId } from "../utils/planUtils";
 import { Scheduler } from "../services/scheduler";
@@ -51,7 +51,9 @@ const VALID_CAREERS = Object.keys(AVAILABLE_PLANS);
 export default function CareerPage({}: PageProps) {
   const { career } = useParams();
   const searchParams = useSearchParams();
+  const { subjects, loading: loadingSubjects } = useSubjects();
   const normalizedPlan = searchParams.get("plan");
+  const preselectedSubjectsIds = searchParams.getAll("code");
   const plan = normalizedPlan ? denormalizePlanId(normalizedPlan) : null;
   const [modalOpen, setModalOpen] = useState(false);
   const [selectedCourseForModal, setSelectedCourseForModal] =
@@ -95,6 +97,24 @@ export default function CareerPage({}: PageProps) {
     );
     redirect(`/${career}?plan=${defaultPlan}`);
   }
+
+  // Add the preselected to the selected courses
+  useEffect(() => {
+    if (preselectedSubjectsIds.length && subjects.length) {
+      const preselectedSubjects = subjects.filter((subject) =>
+        preselectedSubjectsIds.includes(subject.subject_id)
+      );
+
+      setSelectedCourses((prev) => [
+        ...prev,
+        ...preselectedSubjects.map((subject) => ({
+          ...subject,
+          selectedCommissions: subject.commissions.map((c) => c.name),
+          isPriority: false,
+        })),
+      ]);
+    }
+  }, [loadingSubjects]);
 
   const handleCommissionSelect = (commissions: string[]) => {
     if (selectedCourseForModal) {

--- a/app/[career]/page.tsx
+++ b/app/[career]/page.tsx
@@ -51,9 +51,9 @@ const VALID_CAREERS = Object.keys(AVAILABLE_PLANS);
 export default function CareerPage({}: PageProps) {
   const { career } = useParams();
   const searchParams = useSearchParams();
-  const { subjects, loading: loadingSubjects } = useSubjects();
+  const { subjects } = useSubjects();
   const normalizedPlan = searchParams.get("plan");
-  const preselectedSubjectsIds = searchParams.getAll("code");
+  const preselectedSubjectsIds = useRef(searchParams.getAll("code"));
   const plan = normalizedPlan ? denormalizePlanId(normalizedPlan) : null;
   const [modalOpen, setModalOpen] = useState(false);
   const [selectedCourseForModal, setSelectedCourseForModal] =
@@ -100,9 +100,9 @@ export default function CareerPage({}: PageProps) {
 
   // Add the preselected to the selected courses
   useEffect(() => {
-    if (preselectedSubjectsIds.length && subjects.length) {
+    if (preselectedSubjectsIds.current.length && subjects.length) {
       const preselectedSubjects = subjects.filter((subject) =>
-        preselectedSubjectsIds.includes(subject.subject_id)
+        preselectedSubjectsIds.current.includes(subject.subject_id)
       );
 
       setSelectedCourses((prev) => [
@@ -114,7 +114,7 @@ export default function CareerPage({}: PageProps) {
         })),
       ]);
     }
-  }, [loadingSubjects]);
+  }, [subjects]);
 
   const handleCommissionSelect = (commissions: string[]) => {
     if (selectedCourseForModal) {


### PR DESCRIPTION
Quería colaborar con su página agregando una función que permitiría seleccionar las materias mediante searchParams. Esto se puede utilizar ya sea para compartir con otros usuarios un set de materias pre-seleccionadas, como también ofrecer sistemas automáticos de vínculos entre páginas (por ejemplo, https://github.com/Secreto31126/correlativas-itba/pull/32).

Para poder implementarlo, tuve que importar `useSubjects` en el page.tsx principal, dado que ahí era el mejor punto de encuentro entre useSearchParams y la información de la API. Espero que esto no sea un problema.

Closes #15 