### PR TITLE
feat(ci): publish dist.zip as latest GitHub Release on main push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,10 +27,19 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Upload artifact
-        if: github.event_name == 'push'
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-${{ github.ref_name }}-${{ github.sha }}
-          path: dist/
-          retention-days: 30
+      - name: Zip dist
+        if: github.ref == 'refs/heads/main'
+        run: zip -r dist.zip dist/
+
+      - name: Release
+        if: github.ref == 'refs/heads/main'
+        run: |
+          gh release delete latest --yes 2>/dev/null || true
+          git tag -f latest
+          git push origin latest --force
+          gh release create latest dist.zip \
+            --title "Latest build" \
+            --notes "Built from commit ${{ github.sha }}" \
+            --latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces the plain artifact upload with a GitHub Release so `dist.zip` is always available at a stable `latest` tag
- Other repos can download it via `gh release download latest --repo ceitba/scheduler --pattern "dist.zip"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)