### PR TITLE
feat(ci): add SSH deploy step to VPS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,3 +43,21 @@ jobs:
             --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy to VPS
+        if: github.ref == 'refs/heads/main'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            mkdir -p /var/www/scheduler
+            cd /tmp
+            rm -rf dist dist.zip
+            gh release download latest --repo ceitba/scheduler --pattern "dist.zip" --clobber
+            unzip -o dist.zip
+            rsync -a --delete dist/ /var/www/scheduler/
+            rm -rf dist dist.zip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds SSH deploy step using `appleboy/ssh-action`
- Downloads the release zip on the VPS and rsyncs it to `/var/www/scheduler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)