### PR TITLE
feat: configurable base path for subpath deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          VITE_BASE_PATH: /scheduler/
 
       - name: Zip dist
         if: github.ref == 'refs/heads/main'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import CareerPage from './pages/CareerPage'
 export default function App() {
   return (
     <ThemeProvider>
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/:career" element={<CareerPage />} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  base: process.env.VITE_BASE_PATH ?? '/',
 })


### PR DESCRIPTION
## Summary
- `VITE_BASE_PATH` env var controls the subpath (default `/`)
- `BrowserRouter` uses `import.meta.env.BASE_URL` so routing matches the build-time base
- Workflow sets `VITE_BASE_PATH=/scheduler/` at build time

## Nginx config needed on VPS
\`\`\`nginx
location /scheduler/ {
    alias /var/www/scheduler/;
    try_files \$uri \$uri/ /scheduler/index.html;
}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)